### PR TITLE
feature: Rotate all labels at once using annotation_rotation

### DIFF
--- a/src/graphlan_lib.py
+++ b/src/graphlan_lib.py
@@ -143,7 +143,7 @@ class CircTree(PpaTree):
         for line in (l.strip().split('\t') for l in lines if l[0] != '#'):
             if not ''.join(line): # skip empty lines
                 continue
-    
+
             ll = len(line)
 
             if (ll < 2) or (ll > 4):
@@ -826,8 +826,21 @@ class CircTree(PpaTree):
                     avgtheta = (lgr + lsm)*0.5
                     self._label_theta.append( avgtheta )
 
-                    rot90 = hasattr(clade, 'annotation_rotation') and clade.annotation_rotation
-                    fract = 0.05 if rot90 else 0.5
+                    # Default values for fract and rot90
+                    fract = 0.5
+                    rot90 = False
+
+                    # If the option 'annotation_rotation' is given as global option and != 0, rotate
+                    if self.default_annotation_rotation:
+                        fract = 0.05
+                        rot90 = True
+
+                    clade_rot90 = hasattr(clade, 'annotation_rotation') and clade.annotation_rotation
+
+                    # If the option 'annotation_rotation' is given as clade option, overwrite fract and rot90
+                    if hasattr(clade, 'annotation_rotation'):
+                        fract = 0.05 if clade_rot90 else 0.5
+                        rot90 = clade_rot90
 
                     if self.ignore_branch_len:
                         rad = 1.0 + lev_width * ( 1 + self._wing_levs.index(int(self._depths[clade.name]))  ) - lev_width * fract


### PR DESCRIPTION
Hi,

Thanks a lot for this amazing software, I have found it very useful!
I was using GraPhlAn and wanted a way to rotate all labels at once, and avoid editing clade by clade in the annotation file, so this was my way to do it.

I am biologist and I have not formal formation in programming, and I don't understand completely the working of GraPhlAn, so I apologize in advance if there are issues with this code. However, I have tested it in some cases (not a thorough testing) and it worked without problems.

The main idea is to be able to rotate 90° all labels by setting `annotation_rotation	90` in the annotation file. If `annotation_rotation` is set in a clade, it overrides the global option. `annotation_rotation` still have two possible values: 0 and 90.

Here is an [example annotation file](https://github.com/biobakery/graphlan/files/6475893/glob_90_clade_0.annot.txt) showing how the new feature would be used. I also provide the corresponding input [tree](https://github.com/biobakery/graphlan/files/6475895/merged_abundance.tree.txt) for `graphlan_annotate.py`. The output should be:

![glob_90_clade_0](https://user-images.githubusercontent.com/63323077/118206243-b77bcc00-b427-11eb-8c59-ef5869dadb37.png)

Hope you find it useful and if not implementable maybe can help to shed some light in the implementation of this feature.
Thanks!